### PR TITLE
Fix a not found connector

### DIFF
--- a/core/components/simpleupdater/processors/mgr/version/check.class.php
+++ b/core/components/simpleupdater/processors/mgr/version/check.class.php
@@ -20,7 +20,7 @@ class simpleUpdaterCheckProcessor extends modProcessor
         $object = array(
             'success' => true,
             'show_button' => false,
-            'connector_url' => $simpleupdater->getOption('assets_url') . 'components/simpleupdater/connector.php'
+            'connector_url' => $simpleupdater->getOption('assetsUrl') . 'components/simpleupdater/connector.php'
         );
         $ttl = 6 * 60 * 60;
         $registry = $this->modx->getService('registry', 'registry.modRegistry');

--- a/core/components/simpleupdater/processors/mgr/version/check.class.php
+++ b/core/components/simpleupdater/processors/mgr/version/check.class.php
@@ -20,7 +20,7 @@ class simpleUpdaterCheckProcessor extends modProcessor
         $object = array(
             'success' => true,
             'show_button' => false,
-            'connector_url' => $simpleupdater->getOption('assetsUrl') . 'components/simpleupdater/connector.php'
+            'connector_url' => $simpleupdater->getOption('connectorUrl')
         );
         $ttl = 6 * 60 * 60;
         $registry = $this->modx->getService('registry', 'registry.modRegistry');


### PR DESCRIPTION
For the update button in the menu.

Sorry, I did not detect this bug during development, because the system setting simpleupdater.assets_url exists on my installation.